### PR TITLE
Make the image run with newer wasmedge shims

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: build
 
 on:
   push:
@@ -9,8 +9,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
@@ -22,5 +20,5 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: michaelirwin244/wasm-github-action-demo:latest
-          platforms: wasi/wasm
+          tags: michaelirwin244/wasm-example:latest
+          platforms: wasi/wasm32

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ RUN <<EOT bash
         clang
     rustup target add wasm32-wasi
 EOT
-# This line installs WasmEdge including the AOT compiler
-RUN curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash
 
 FROM buildbase AS build
 COPY . .
@@ -20,9 +18,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/cache \
     --mount=type=cache,target=/usr/local/cargo/registry/index \
     cargo build --target wasm32-wasi --release
-# This line builds the AOT Wasm binary
-RUN /root/.wasmedge/bin/wasmedgec target/wasm32-wasi/release/hello_world.wasm hello_world.wasm
 
 FROM scratch
-ENTRYPOINT [ "hello_world.wasm" ]
-COPY --link --from=build /src/hello_world.wasm /hello_world.wasm
+ENTRYPOINT [ "/hello_world.wasm" ]
+COPY --link --from=build /src/target/wasm32-wasi/release/hello_world.wasm /hello_world.wasm

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Lightweight and secure microservice with a database backend
 
-In this repo, we demonstrate a microservice written in Rust, and connected to a MySQL database. It supports CURD operations on a database table via a HTTP service interface. The microservice is compiled into WebAssembly and runs in the WasmEdge Runtime, which is a secure and lightweight alternative to natively compiled Rust apps in Linux containers. The WasmEdge Runtime can be managed and orchestrated by container tools such as the Docker CLI, Podman, as well as almost all flavors of Kubernetes. It also works with microservice management frameworks such as Dapr.
+In this repo, we demonstrate a simple http server written in Rust. The server is compiled into WebAssembly and runs in the WasmEdge Runtime, which is a secure and lightweight alternative to natively compiled Rust apps in Linux containers. The WasmEdge Runtime can be managed and orchestrated by container tools such as the Docker CLI, Podman, as well as almost all flavors of Kubernetes. It also works with microservice management frameworks such as Dapr.
 
-> Everything described in this document is captured in the [GitHub Actions CI workflow](.github/workflows/ci.yml).
+> Everything described in this document is captured in the [GitHub Actions build workflow](.github/workflows/build.yml).
 
 
 ## Test with Docker
@@ -13,20 +13,14 @@ Using a version of Docker with Wasm WASI support, start the example stack using 
 docker compose up
 ```
 
-Initialize the database using the `/init` endpoint:
+Get the server's root endpoint:
 
 ```bash
-docker run --rm --network host curlimages/curl curl http://localhost:8080/init
+docker run --rm --network host curlimages/curl curl -sw'\n' http://localhost:8080/
 ```
 
-List the current orders using the `/orders` endpoint:
+Post to the server's `/echo` endpoint:
 
 ```bash
-docker run --rm --network host curlimages/curl curl http://localhost:8080/orders
-```
-
-Add the example orders:
-
-```bash
-cat orders.json | docker run --rm --network host -i curlimages/curl curl http://localhost:8080/create_orders -X POST -d @-
+docker run --rm --network host curlimages/curl curl -sw'\n' -X POST -d 'hello world' http://localhost:8080/echo
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,11 @@
 services:
   server:
-    image: server
+    image: wasm-example
     build:
       context: .
       platforms:
         - wasi/wasm32
     ports:
       - 8080:8080
-    network_mode: host
-    environment:
-      DATABASE_URL: mysql://root:whalehello@localhost:3306/mysql
-      RUST_BACKTRACE: full
     restart: unless-stopped
     runtime: io.containerd.wasmedge.v1
-  db:
-    image: mariadb:10.9
-    environment:
-      MYSQL_ROOT_PASSWORD: whalehello
-    network_mode: host


### PR DESCRIPTION
Newer wasmedge shims are stricter on the image requirements:
* The entrypoint path now requires normal posix executable resolution (i.e., in `PATH`, or contain at least one `/`).
* The entrypoint binary must be executable.

The first is easily fixed using an absolute path.

For the second, we can use the binary generated by `rustc` directly. The binary generated by `rustc` is executable, but the binary generated by `wasmedgec` is not.

The `wasmedgec` step is optional, so we can do without it. This also simplifies the example.

I also took the oportunity to fix some files that seem to mismatch the actual example code.
In particular, PTAL at the changes in `build.yaml`